### PR TITLE
Update sourmash to 0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mgnify-sourmash-component",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5934,9 +5934,9 @@
       "dev": true
     },
     "sourmash": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/sourmash/-/sourmash-0.6.0.tgz",
-      "integrity": "sha512-vIfDO6vIwbGAW/R+Wox6UVIq5tWCmdkFZ4w6E/nlRBn+oeOJIk56qgnhmAuouPHaa5a7nAYIz2sqvQB1ZLTf3g=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/sourmash/-/sourmash-0.11.0.tgz",
+      "integrity": "sha512-/UZkuTqzO2ptrPrtvZw2QmDrJkEnAdgVB9VMJxnRkFk0Qkuq2MXooJey0zF6AGE3ry8Yaa1l+znOmI1KOCunYA=="
     },
     "spdx-correct": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "peek-stream": "1.1.3",
     "process": "0.11.10",
     "pumpify": "2.0.1",
-    "sourmash": "0.6.0",
+    "sourmash": "0.11.0",
     "stream": "0.0.2",
     "through2": "4.0.2",
     "util": "0.12.4",


### PR DESCRIPTION
With https://github.com/sourmash-bio/sourmash/pull/1643 released as `0.11.0` the problem with missing files are solved.

(I also updated the `package-lock.json` file, I think it missed some version bumps)