### PR TITLE
Capitalised FASTA label to be more in line with general standards

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,7 @@ export class MGnifySourmash extends LitElement {
     return html`
       <div class="mgnify-sourmash-component">
         <label
-          >Select ${this.is_protein ? 'protein' : 'nucleotides'} FastA
+          >Select ${this.is_protein ? 'protein' : 'nucleotides'} FASTA
           files:</label
         >
         <label class="file" for="sourmash-selector">


### PR DESCRIPTION
This PR simply corrects the typo in the spelling of FASTA. 
Changed from "fastA" to "FASTA"